### PR TITLE
Update 'use' keys

### DIFF
--- a/EO.l10n
+++ b/EO.l10n
@@ -684,7 +684,7 @@ phaser-UNDO      MALFARU
 #pragma-strict              strict
 #pragma-trace               trace
 #pragma-variables           variables
-#pragma-worries             worries
+pragma-worries             zorgojn
 
 # KEY       TRANSLATION
 prefix-not   ne

--- a/EO.l10n
+++ b/EO.l10n
@@ -787,10 +787,10 @@ traitmod-returns   resendas
 typer-subset   subaro
 
 # KEY        TRANSLATION
-use-import    importas
-use-need      bezonas
-#use-no       no
-use-require   postulas
-use-use       uzas
+use-import    importu
+use-need      bezonu
+use-no        forneu
+use-require   postulu
+use-use       uzu
 
 # vim: expandtab shiftwidth=4

--- a/EO.l10n
+++ b/EO.l10n
@@ -679,11 +679,11 @@ phaser-UNDO      MALFARU
 #pragma-MONKEY-SEE-NO-EVAL  MONKEY-SEE-NO-EVAL
 #pragma-MONKEY-TYPING       MONKEY-TYPING
 #pragma-nqp                 nqp
-#pragma-precompilation      precompilation
-#pragma-soft                soft
-#pragma-strict              strict
-#pragma-trace               trace
-#pragma-variables           variables
+pragma-precompilation      antaŭtradukadon
+pragma-soft                molecon
+pragma-strict              striktecon
+pragma-trace               spurantan
+pragma-variables           variablojn
 pragma-worries             zorgojn
 
 # KEY       TRANSLATION

--- a/EO.l10n
+++ b/EO.l10n
@@ -788,9 +788,9 @@ typer-subset   subaro
 
 # KEY        TRANSLATION
 use-import    importu
-use-need      bezonu
+use-need      antaŭŝargu
 use-no        forneu
-use-require   postulu
+use-require   ŝargu
 use-use       uzu
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
I view the `use` statements as grammatically being the imperative form. This view is reinforced by Perligata choosing the Latin imperative `ute`: https://metacpan.org/dist/Lingua-Romana-Perligata/view/lib/Lingua/Romana/Perligata.pm#Packages,-classes,-and-modules1

I have opted for `forneu` as `nei` is to deny, and the prefix `for-` gives the concept of distancing or removal/destruction. However I have hesitance for it as it may be archaic (it seems to be mainly referenced in Bible translations). Alternatives I am considering are `neu` and `forlasu`.

I have translated `worries` into the accusative case `zorgojn`, as pragmas are to be enabled/disabled with `uzu/forneu`.